### PR TITLE
fix problem with migrations first setup

### DIFF
--- a/lib/persistence.migrations.js
+++ b/lib/persistence.migrations.js
@@ -38,7 +38,7 @@ if(!window.persistence) { // persistence.js not loaded!
         persistence.transaction(function(t){
           t.executeSql('SELECT current_version FROM schema_version', null, function(result){
             if (result.length == 0) {
-              t.executeSql('INSERT INTO schema_version VALUES (0)', function(){
+              t.executeSql('INSERT INTO schema_version VALUES (0)', null, function(){
                 callback(0);
               });
             } else {


### PR DESCRIPTION
Fixed the call to insert first record on schema_version, in previous version it's not calling the callback (because the callback was sent as second argument, but need to be the third), so the users need to go into page twice in order to migrations run, this commit fix this issue.
