### PR TITLE
Cleaner transaction API

### DIFF
--- a/lib/persistence.store.mysql.js
+++ b/lib/persistence.store.mysql.js
@@ -26,8 +26,19 @@ exports.config = function(persistence, hostname, db, username, password) {
     conn.connect();
 
     var session = new persistence.Session(that);
-    session.transaction = function (fn) {
-      return fn(transaction(conn));
+    session.transaction = function (explicitCommit, fn) {
+      if (typeof arguments[0] === "function") {
+        fn = arguments[0];
+        explicitCommit = false;
+      }
+      var tx = transaction(conn);
+      if (explicitCommit) {
+        tx.executeSql("START TRANSACTION", null, function(){
+          fn(tx)
+        });
+      }
+      else 
+        fn(tx);
     };
 
     session.close = function() {
@@ -37,32 +48,13 @@ exports.config = function(persistence, hostname, db, username, password) {
     return session;
   };
 
-  function transaction(conn) {
+  function transaction(conn){
     var that = {};
-	var started;
-    that.executeSql = function (query, args, successFn, errorFn) {
-	  
-	  function doIt(query, args, cb) {
-	  	if (persistence.debug)
-		  sys.print(query + "\n");
-        if(!args) {
-          conn.query(query, cb);
-        } else {
-          conn.query(query, args, cb);
-        }
-	  }
-
-      function cb(err, result) {
-        if(err) {
-		  if (that.explicitCommit && started) {
-      		doIt("ROLLBACK", null, function() {
-				started = false;
-				cb(err);
-			});
-			return;
-		  }
+    that.executeSql = function(query, args, successFn, errorFn){
+      function cb(err, result){
+        if (err) {
           log(err.message);
-		  that.errorHandler && that.errorHandler(err);
+          that.errorHandler && that.errorHandler(err);
           errorFn && errorFn(null, err);
           return;
         }
@@ -70,24 +62,33 @@ exports.config = function(persistence, hostname, db, username, password) {
           successFn(result);
         }
       }
-	  if (that.explicitCommit && !started) {
-		doIt("START TRANSACTION", null, function(err) {
-			if (err)
-				cb(err);
-			else {
-				started = true;
-				that.executeSql(query, args, successFn, errorFn);
-			}
-		});
-		return;
-	  }
-	  if (query == "COMMIT")
-	  	started = false;
-		
-	  doIt(query, args, cb);
-    };
+      if (persistence.debug) {
+        sys.print(query + "\n");
+        args && args.length > 0 && sys.print(args.join(",") + "\n")
+      }
+      if (!args) {
+        conn.query(query, cb);
+      }
+      else {
+        conn.query(query, args, cb);
+      }
+    }
+    
+    that.commit = function(session, callback){
+      session.flush(that, function(){
+        that.executeSql("COMMIT", null, callback);
+      })
+    }
+    
+    that.rollback = function(session, callback){
+      that.executeSql("ROLLBACK", null, function() {
+        session.clean();
+        callback();
+      });
+    }
     return that;
   }
+  
   exports.mysqlDialect = {
     columnTypeToSql: function(type) {
       switch(type) {

--- a/lib/persistence.store.sql.js
+++ b/lib/persistence.store.sql.js
@@ -179,21 +179,6 @@ persistence.store.sql.config = function(persistence, dialect) {
       }
     }
   };
-
-  /**
-   * Commits all changes to the database, use instead of flush if you
-   * use transactions
-   * 
-   * @param tx
-   *            transaction to use
-   * @param callback
-   *            function to be called when done
-   */
-  persistence.commit = function(tx, callback){
-  	this.flush(tx, function() {
-        tx.executeSql("COMMIT", null, callback);
-      });
-  };
   
   /**
    * Remove all tables in the database (as defined by the model)


### PR DESCRIPTION
Hi Zef,

I did a review of the commit/rollback API. I've put details in the commit log. I'm not completely sure about the session.clean() call in transaction.rollback() but I have the impression that this is the right thing to do here (we have to rollback cached data too).

Also, I added an optional first parameter to session.transaction(), to handle the autoCommit/explicitCommit switch. Would be nice if the other engines could ignore this parameter if they cannot handle it. If you have a better idea for this API, let me know, I'll make the change.

Bruno
