### PR TITLE
Added error handling for persistence

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -333,10 +333,10 @@ persistence.get = function(arg1, arg2) {
         callback();
       }
       for(var i = 0; i < array.length; i++) {
-        fn(array[i], function() {
+        fn(array[i], function(result, err) {
             completed++;
             if(completed === array.length) {
-              callback();
+              callback(result, err);
             }
           });
       }

--- a/lib/persistence.store.sql.js
+++ b/lib/persistence.store.sql.js
@@ -415,10 +415,10 @@ persistence.store.sql.config = function(persistence, dialect) {
           qs.push(tm.outIdVar('?'));
           var sql = "INSERT INTO `" + obj._type + "` (" + properties.join(", ") + ") VALUES (" + qs.join(', ') + ")";
           obj._new = false;
-          tx.executeSql(sql, values, callback);
+          tx.executeSql(sql, values, callback, callback);
         } else {
           var sql = "UPDATE `" + obj._type + "` SET " + propertyPairs.join(',') + " WHERE id = " + tm.outId(obj.id);
-          tx.executeSql(sql, values, callback);
+          tx.executeSql(sql, values, callback, callback);
         }
       });
   }

--- a/test/test.error.handling.js
+++ b/test/test.error.handling.js
@@ -1,0 +1,30 @@
+var assert = require('assert');
+var persistence = require('../lib/persistence').persistence;
+var persistenceStore = require('../lib/persistence.store.mysql');
+
+persistenceStore.config(persistence, 'localhost', 3306, 'nodejs_mysql', 'test', 'test');
+
+var NotExist = persistence.define('NotExist', {
+  name: "TEXT"
+});
+
+var create = function(data, cb) {
+  var session = persistenceStore.getSession();
+  var ne = new NotExist(data);
+  session.add(ne);
+  session.flush(function(result, err) {
+    session.close();
+    cb && cb(err, result);
+  });
+};
+
+module.exports = {
+  'create fail': function(done) {
+    create({
+      name: 'test'
+    }, function(err, result) {
+      assert.isDefined(err);
+      done();
+    });
+  }
+};


### PR DESCRIPTION
Modified persistence.asyncParForEach() so as to pass an error object to flush()'s callback.
