### PR TITLE
Fixed bug of persistence.flush(), to remove objects.

### DIFF
--- a/lib/persistence.store.memory.js
+++ b/lib/persistence.store.memory.js
@@ -120,6 +120,10 @@ persistence.store.memory.config = function(persistence) {
     callback();
   };
 
+  /**
+   * Dummy
+   */
+  persistence.close = function() {};
 
   // QueryCollection's list
 
@@ -226,5 +230,6 @@ persistence.store.memory.config = function(persistence) {
 
 try {
   exports.config = persistence.store.memory.config;
+  exports.getSession = function() { return persistence; };
 } catch(e) {}
 

--- a/test/node/test.memory.store.js
+++ b/test/node/test.memory.store.js
@@ -1,6 +1,9 @@
-var persistence = require('../../lib/persistence').persistence;
-require('../../lib/persistence.store.memory').config(persistence);
+// $ expresso -s test.memory.store.js
+
 var assert = require('assert');
+var persistence = require('../../lib/persistence').persistence;
+var persistenceStore = require('../../lib/persistence.store.memory');
+persistenceStore.config(persistence);
 
 var Task = persistence.define('Task', {
   username: 'TEXT'
@@ -9,14 +12,48 @@ var Task = persistence.define('Task', {
 var data = {
   username: 'test'
 };
-persistence.schemaSync();
-var task = new Task(data);
-persistence.add(task);
-persistence.flush(function(result, err) {
-  persistence.remove(task);
-  persistence.flush(function(result, err) {
-    Task.findBy('id', task.id, function(task) {
-      assert.equal(task, null);
+
+var task, session;
+
+module.exports = {
+  init: function(done) {
+    persistence.schemaSync();
+    session = persistenceStore.getSession();
+    done();
+  },
+  add: function(done) {
+    task = new Task(data);
+    session.add(task);
+    session.flush(function(result, err) {
+      assert.ifError(err);
+      done();
     });
-  });
-});
+  },
+  get: function(done) {
+    Task.findBy(session, 'id', task.id, function(task) {
+      assert.equal(task.username, data.username);
+      done();
+    });
+  },
+  update: function(done) {
+    task.username = 'test2';
+    Task.findBy(session, 'id', task.id, function(task) {
+      assert.equal(task.username, 'test2');
+      done();
+    });
+  },
+  remove: function(done) {
+    session.remove(task);
+    session.flush(function(result, err) {
+      assert.ifError(err);
+      Task.findBy(session, 'id', task.id, function(task) {
+        assert.equal(task, null);
+        done();
+      });
+    });
+  },
+  afterAll: function(done) {
+    session.close();
+    done();
+  }
+};


### PR DESCRIPTION
Hi,

I found a in-memory store bug not to remove objects when I called persistence.remove().
It was because persistence.flush() in presistence.store.memory.js didn't remove trackedObjects.
