### PR TITLE
Adding the ability to specify which localStorage variable to write to.

### DIFF
--- a/lib/persistence.store.memory.js
+++ b/lib/persistence.store.memory.js
@@ -16,8 +16,9 @@ if(!persistence.store) {
 
 persistence.store.memory = {};
 
-persistence.store.memory.config = function(persistence) {
+persistence.store.memory.config = function(persistence, dbname) {
   var argspec = persistence.argspec;
+  dbname = dbname || 'persistenceData';
 
   var allObjects = {}; // entityName -> LocalQueryCollection
 
@@ -87,17 +88,17 @@ persistence.store.memory.config = function(persistence) {
   };
 
   persistence.loadFromLocalStorage = function(callback) {
-    var dump = window.localStorage.getItem('persistenceData');
+    var dump = window.localStorage.getItem(dbname);
     if(dump) {
       this.loadFromJson(dump, callback);
     } else {
-      callback();
+      callback && callback();
     }
   };
 
   persistence.saveToLocalStorage = function(callback) {
     this.dumpToJson(function(dump) {
-        window.localStorage.setItem('persistenceData', dump);
+        window.localStorage.setItem(dbname, dump);
         if(callback) {
           callback();
         }


### PR DESCRIPTION
Just as the WebSQL adapter has the ability to specify the name of the DB to write to, localStorage should have this capability as well.  I have added a second formal parameter to the persistence.memory.configure function specifying the localStorage variable name.  If none is given, it falls back to the default "persistenceData" name.

Thanks, fantastic library here!
