### PR TITLE
export modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,2 @@
+module.exports = require('./persistence').persistence;
+module.exports.StoreConfig = require('./persistence.store.config');


### PR DESCRIPTION
The current node example in the readme is invalid (I could not get it to work). Newer versions of node treat modules differently than past versions. This exports the persistence module as well as the store config module for the following use example:

```
var persistence = require('persistencejs');
var PersistenceConfig = require('persistencejs').StoreConfig;
var siteStore = PersistenceConfig.init(persistence, {
    adaptor: 'mysql',
    ...
});
```

This patch may need to be expanded upon depending if other files need to be exposed.
