### PR TITLE
Fixed regexp to handle quotations around table and column names sometime used by chrome

### DIFF
--- a/lib/persistence.migrations.js
+++ b/lib/persistence.migrations.js
@@ -217,12 +217,12 @@ if(!window.persistence) { // persistence.js not loaded!
       this.action(function(tx, nextCommand){
         var sql = 'select sql from sqlite_master where type = "table" and name == "'+tableName+'"';
         tx.executeSql(sql, null, function(result){
-          var columns = new RegExp("CREATE TABLE \\w+ \\((.+)\\)").exec(result[0].sql)[1].split(', ');
+          var columns = new RegExp("CREATE TABLE `\\w+` |\\w+ \\((.+)\\)").exec(result[0].sql)[1].split(', ');
           var selectColumns = [];
           var columnsSql = [];
           
           for (var i = 0; i < columns.length; i++) {
-            var colName = new RegExp("(\\w+) .+").exec(columns[i])[1];
+            var colName = new RegExp("((`\\w+`)|(\\w+)) .+").exec(columns[i])[1];
             if (colName == columnName) continue;
             
             columnsSql.push(columns[i]);


### PR DESCRIPTION
My tables somehow got wrapped with a special quotation character which the current regexp did not seem to cope with I have made changes that fixed that. Perhaps you could look at it and if seems like something you want merge it..

Best regards!
