### PR TITLE
Updates for Node 0.6

### DIFF
--- a/lib/persistence.pool.js
+++ b/lib/persistence.pool.js
@@ -1,4 +1,4 @@
-var sys = require('sys');
+var sys = require('util');
 var mysql = require('mysql');
 
 function log(o) {

--- a/lib/persistence.store.mysql.js
+++ b/lib/persistence.store.mysql.js
@@ -46,7 +46,7 @@ exports.config = function(persistence, hostname, port, db, username, password) {
       //conn._connection.destroy();
     };
     session.conn = conn;
-    conn.connect(cb);
+    if(cb) cb();
     return session;
   };
 

--- a/lib/persistence.store.mysql.js
+++ b/lib/persistence.store.mysql.js
@@ -4,7 +4,7 @@
  * Easy install using npm:
  *   npm install mysql
  */
-var sys = require('sys');
+var sys = require('util');
 var sql = require('./persistence.store.sql');
 var mysql = require('mysql');
 
@@ -47,7 +47,9 @@ exports.config = function(persistence, hostname, port, db, username, password) {
       //conn._connection.destroy();
     };
     session.conn = conn;
-    if(cb) cb();
+    if(cb) {
+      cb();
+    }
     return session;
   };
 

--- a/lib/persistence.store.mysql.js
+++ b/lib/persistence.store.mysql.js
@@ -18,7 +18,7 @@ function log(o) {
 exports.config = function(persistence, hostname, port, db, username, password) {
   exports.getSession = function(cb) {
     var that = {};
-    var conn = new mysql.Client();
+    var conn = mysql.createClient();
     conn.host = hostname;
     conn.port = port;
     conn.user = username;

--- a/lib/persistence.store.mysql.js
+++ b/lib/persistence.store.mysql.js
@@ -18,12 +18,13 @@ function log(o) {
 exports.config = function(persistence, hostname, port, db, username, password) {
   exports.getSession = function(cb) {
     var that = {};
-    var conn = mysql.createClient();
-    conn.host = hostname;
-    conn.port = port;
-    conn.user = username;
-    conn.password = password;
-    conn.database = db;
+    var conn = mysql.createClient({
+      host : hostname,
+      port : port,
+      user : username,
+      password : password,
+      database : db
+    });
 
     var session = new persistence.Session(that);
     session.transaction = function (explicitCommit, fn) {

--- a/lib/persistence.store.sqlite.js
+++ b/lib/persistence.store.sqlite.js
@@ -5,7 +5,7 @@
  *   npm install sqlite
  * @author Eugene Ware
  */
-var sys = require('sys');
+var sys = require('util');
 var sql = require('./persistence.store.sql');
 var sqlite = require('sqlite');
 

--- a/lib/persistence.sync.server.js
+++ b/lib/persistence.sync.server.js
@@ -28,7 +28,7 @@
  * otherwise the application will hang (because the select query fails). After that,
  * just visit http://localhost:8888/
  */
-var sys = require('sys');
+var sys = require('util');
 
 function log(o) {
   sys.print(sys.inspect(o) + "\n");
@@ -76,7 +76,7 @@ exports.pushUpdates = function(session, tx, Entity, since, callback) {
   }
   queryCollection.filter("_lastChange", ">", since).list(tx, function(items) {
       var results = [];
-      var meta = Entity.meta;
+      var meta = session.getMeta(queryCollection._entityName);
       var fieldSpec = meta.fields;
       for(var i = 0; i < items.length; i++) {
         var itemData = items[i]._data;

--- a/lib/persistence.sync.server.js
+++ b/lib/persistence.sync.server.js
@@ -97,7 +97,7 @@ exports.pushUpdates = function(session, tx, Entity, since, callback) {
           for(var i = 0; i < items.length; i++) {
             results.push({id: items[i].id, _removed: true});
           }
-          callback({now: getEpoch(new Date()), updates: results});
+          if(callback) callback({now: getEpoch(new Date()), updates: results});
         });
     });
 };

--- a/lib/persistence.sync.server.js
+++ b/lib/persistence.sync.server.js
@@ -97,7 +97,7 @@ exports.pushUpdates = function(session, tx, Entity, since, callback) {
           for(var i = 0; i < items.length; i++) {
             results.push({id: items[i].id, _removed: true});
           }
-          if(callback) callback({now: getEpoch(new Date()), updates: results});
+          callback({now: getEpoch(new Date()), updates: results});
         });
     });
 };


### PR DESCRIPTION
Zef,

I just pushed my setup from node 0.4.11 to 0.6.1. I also updated all the modules, which I had not done in a good while. Here are the changes that I had to make to get persistence to work again. 

The SYS module is now called UTIL. I was lazy and just changed the require lines.

The node_mysql module creates connections differently now. You're supposed to use mysql.createClient() instead of new Client(). Also, you can't call the connect() method on your mysql client. 

I'm pretty sure these changes will break things for people who aren't up to date, so I wouldn't pull this if you aren't ready to force everyone to upgrade.

Cheers,
Jake

EDIT: Would this make more sense as a branch? Feel free to kill this pull if you think we should treat it differently.