### PR TITLE
Fixed persistence.sync.js so that it works when syncing delete to another server

### DIFF
--- a/lib/persistence.sync.js
+++ b/lib/persistence.sync.js
@@ -198,7 +198,7 @@ persistence.sync.postJSON = function(uri, data, callback) {
                   var removedObjColl = persistence.sync.RemovedObject.all(session).filter("entity", "=", meta.name);
                   removedObjColl.list(function(objs) {
                       objs.forEach(function(obj) {
-                          updatesToPush.push({id: obj.id, _removed: true});
+                          updatesToPush.push({id: obj.objectId, _removed: true});
                         });
                       function next() {
                         removedObjColl.destroyAll(function() {


### PR DESCRIPTION
Appending obj.id sends the id from the _SyncRemovedObject table.
