### PR TITLE
Check for values in milliseconds 

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -1016,7 +1016,12 @@ persistence.get = function(arg1, arg2) {
         switch(type) {
         case 'DATE':
           if(typeof value === 'number') {
-            return new Date(value * 1000);
+            if (value > 1000000000000) {
+              // it's in milliseconds
+              return new Date(value); 
+            } else {
+              return new Date(value * 1000); 
+            }
           } else {
             return null;
           }

--- a/lib/persistence.store.appengine.js
+++ b/lib/persistence.store.appengine.js
@@ -32,7 +32,12 @@ exports.config = function(persistence) {
     switch (type) {
     case 'DATE':
       // SQL is in seconds and JS in miliseconds
-      return new Date(parseInt(val, 10) * 1000);
+        if (val > 1000000000000) {
+          // usually in seconds, but sometimes it's milliseconds
+          return new Date(parseInt(val, 10));
+        } else {
+          return new Date(parseInt(val, 10) * 1000);
+        }
     case 'BOOL':
       return val === 1 || val === '1';
       break;

--- a/lib/persistence.store.sql.js
+++ b/lib/persistence.store.sql.js
@@ -44,7 +44,12 @@ var defaultTypeMapper = {
     switch (type) {
       case 'DATE':
         // SQL is in seconds and JS in miliseconds
-        return new Date(parseInt(val, 10) * 1000);
+        if (val > 1000000000000) {
+          // usually in seconds, but sometimes it's milliseconds
+          return new Date(parseInt(val, 10));
+        } else {
+          return new Date(parseInt(val, 10) * 1000);
+        }
       case 'BOOL':
         return val === 1 || val === '1';
         break;

--- a/lib/persistence.sync.server.js
+++ b/lib/persistence.sync.server.js
@@ -38,7 +38,12 @@ function jsonToEntityVal(value, type) {
   if(type) {
     switch(type) {
     case 'DATE': 
-      return new Date(value * 1000); 
+      if (value > 1000000000000) {
+        // it's in milliseconds
+        return new Date(value); 
+      } else {
+        return new Date(value * 1000); 
+      }
       break;
     default:
       return value;


### PR DESCRIPTION
Occasionally, a date value will get stored in milliseconds instead of seconds (I believe this may have something to do with persistence.sync.js). As it gets passed back and forth, the date can get mangled so that it is far, far in the future.

The easy solution is to just check the number. If it greater than 1000000000000, then it's almost certainly in ms. 1000000000000 seconds corresponds to Sep 26 33,658 AD (1000000000000 ms corresponds to Sep 08, 2001). If someone needs to address dates later than 31,000 years from now I suggest they roll their own version.

Did this pull request earlier but accidentally had a lot of bad files uploaded here.
