### PR TITLE
Trigger events in persistence.add()

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -149,15 +149,25 @@ persistence.get = function(arg1, arg2) {
       }
     }
 
+    persistence.objectAdded = function(obj) {
+      persistence.objectChanged(obj, ['add', 'change']);
+    }
+
     persistence.objectRemoved = function(obj) {
+      persistence.objectChanged(obj, ['change']);
+    }
+
+    persistence.objectChanged = function(obj, events) {
       var entityName = obj._type;
       if(this.queryCollectionCache[entityName]) {
         var colls = this.queryCollectionCache[entityName];
         for(var key in colls) {
           if(colls.hasOwnProperty(key)) {
             var coll = colls[key];
-            if(coll._filter.match(obj)) { // matched the filter -> was part of collection
-              coll.triggerEvent('change', coll, obj);
+            if(coll._filter.match(obj)) { // matched the filter -> part of collection
+              for(var i = 0; i < events.length; i++) {
+                coll.triggerEvent(events[i], coll, obj);
+              }
             }
           }
         }
@@ -262,6 +272,7 @@ persistence.get = function(arg1, arg2) {
       if (!this.trackedObjects[obj.id]) {
         this.trackedObjects[obj.id] = obj;
         if(obj._new) {
+          this.objectAdded(obj);
           for(var p in obj._data) {
             if(obj._data.hasOwnProperty(p)) {
               this.propertyChanged(obj, p, undefined, obj._data[p]);


### PR DESCRIPTION
When an object is added using persistence.add(), 'add' and 'change' events
are triggered, similar to persistence.remove().

See http://groups.google.com/group/persistencejs/t/fe090ea380275d5c
