### PR TITLE
Duplicate events for QueryCollection.prototype.add()

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -149,25 +149,15 @@ persistence.get = function(arg1, arg2) {
       }
     }
 
-    persistence.objectAdded = function(obj) {
-      persistence.objectChanged(obj, ['add', 'change']);
-    }
-
     persistence.objectRemoved = function(obj) {
-      persistence.objectChanged(obj, ['change']);
-    }
-
-    persistence.objectChanged = function(obj, events) {
       var entityName = obj._type;
       if(this.queryCollectionCache[entityName]) {
         var colls = this.queryCollectionCache[entityName];
         for(var key in colls) {
           if(colls.hasOwnProperty(key)) {
             var coll = colls[key];
-            if(coll._filter.match(obj)) { // matched the filter -> part of collection
-              for(var i = 0; i < events.length; i++) {
-                coll.triggerEvent(events[i], coll, obj);
-              }
+            if(coll._filter.match(obj)) { // matched the filter -> was part of collection
+              coll.triggerEvent('change', coll, obj);
             }
           }
         }
@@ -272,7 +262,6 @@ persistence.get = function(arg1, arg2) {
       if (!this.trackedObjects[obj.id]) {
         this.trackedObjects[obj.id] = obj;
         if(obj._new) {
-          this.objectAdded(obj);
           for(var p in obj._data) {
             if(obj._data.hasOwnProperty(p)) {
               this.propertyChanged(obj, p, undefined, obj._data[p]);


### PR DESCRIPTION
Adding events for persistence.add() introduced duplicate events to be triggered for QueryCollection.prototype.add(). There's even tests failing because of that, unfortunately I had forgotten to run them.

I'm very sorry for the premature pull request. I reverted the commit for now and will be back with a proper fix later.
