### PR TITLE
Support case-insensitive QueryCollection ordering

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -1632,7 +1632,7 @@ persistence.get = function(arg1, arg2) {
       s += '|Order:';
       for(var i = 0; i < this._orderColumns.length; i++) {
         var col = this._orderColumns[i];
-        s += col[0] + ", " + col[1];
+        s += col[0] + ", " + col[1] + ", " + col[2];
       }
       s += '|Prefetch:';
       for(var i = 0; i < this._prefetchFields.length; i++) {
@@ -1719,12 +1719,16 @@ persistence.get = function(arg1, arg2) {
      * Returns a new query collection with an ordering imposed on the collection
      * @param property the property to sort on
      * @param ascending should the order be ascending (= true) or descending (= false)
+     * @param caseSensitive should the order be case sensitive (= true) or case insensitive (= false)
+     *        note: using case insensitive ordering for anything other than TEXT fields yields
+     *        undefinded behavior
      * @return the query collection with imposed ordering
      */
-    QueryCollection.prototype.order = function (property, ascending) {
+    QueryCollection.prototype.order = function (property, ascending, caseSensitive) {
       ascending = ascending === undefined ? true : ascending;
+      caseSensitive = caseSensitive === undefined ? true : caseSensitive;
       var c = this.clone();
-      c._orderColumns.push( [ property, ascending ]);
+      c._orderColumns.push( [ property, ascending, caseSensitive ]);
       return this._session.uniqueQueryCollection(c);
     };
 
@@ -2060,8 +2064,13 @@ persistence.get = function(arg1, arg2) {
           for(var i = 0; i < that._orderColumns.length; i++) {
             var col = that._orderColumns[i][0];
             var asc = that._orderColumns[i][1];
+            var sens = that._orderColumns[i][2];
             var aVal = persistence.get(a, col);
             var bVal = persistence.get(b, col);
+            if (!sens) {
+              aVal = aVal.toLowerCase();
+              bVal = bVal.toLowerCase();
+            }
             if(aVal < bVal) {
               return asc ? -1 : 1;
             } else if(aVal > bVal) {

--- a/lib/persistence.store.sql.js
+++ b/lib/persistence.store.sql.js
@@ -675,7 +675,7 @@ function config(persistence, dialect) {
       sql += " ORDER BY "
       + this._orderColumns.map(
         function (c) {
-          return "`" + mainPrefix + c[0] + "` "
+          return (c[2] ? "`" : "LOWER(`") + mainPrefix + c[0] + (c[2] ? "` " : "`) ")
           + (c[1] ? "ASC" : "DESC");
         }).join(", ");
     }

--- a/test/browser/test.persistence.js
+++ b/test/browser/test.persistence.js
@@ -423,6 +423,28 @@ $(document).ready(function(){
       });
   }
 
+  function textOrderTests(coll, callback) {
+    var taskNames = ['Task A', 'task b', 'Task C', 'task d'];
+    var tasks = [];
+    for(var i = 0; i < taskNames.length; i++) {
+      var t = new Task({name: taskNames[i]});
+      tasks.push(t);
+      coll.add(t);
+    }
+    coll.order('name', true, true).list(function(results) {
+        var expectedIndices = [0, 2, 1, 3];
+        for(var i = 0; i < tasks.length; i++) {
+          equals(results[i].id, tasks[expectedIndices[i]].id, "order check, ascending, case sensitive");
+        }
+        coll.order('name', true, false).list(function(results) {
+            for(var i = 0; i < tasks.length; i++) {
+              equals(results[i].id, tasks[i].id, "order check, ascending, case insensitive");
+            }
+            callback();
+          });
+      });
+  }
+
   function dateOrderTests(coll, callback) {
     var now = new Date();
 
@@ -461,6 +483,17 @@ $(document).ready(function(){
   asyncTest("Local INT order", function() {
       var coll = new persistence.LocalQueryCollection();
       intOrderTests(coll, start);
+    });
+
+  asyncTest("Database TEXT order", function() {
+      var p = new Project({name: "My project"});
+      persistence.add(p);
+      textOrderTests(p.tasks, start);
+    });
+
+  asyncTest("Local TEXT order", function() {
+      var coll = new persistence.LocalQueryCollection();
+      textOrderTests(coll, start);
     });
 
   asyncTest("Database DATE order", function() {


### PR DESCRIPTION
By default, ordering is case sensitive. Using a new parameter of `QueryCollection.order()` it can be made case insensitive. Using case insensitive ordering only makes sense with TEXT fields, using it with anything else will lead to undefined behavior.

I wanted to add a check that throws when case insensitive ordering is used with non-TEXT fields, like this:

```
if (!caseSensitive && getMeta(this._entityName).fields[property] !== 'TEXT')
  throw new Error("Only TEXT fields can be ordered case insensitive");
```

Unfortunately, `this._entityName` is not available for all `LocalQueryCollections`. Any other ideas on how to implement this check?

---

I ran the following tests successfully in Chrome: test.persistence (websql and memory backend), test.jquery-persistence, test.migrations, test.mixin and test.search.
