### PR TITLE
Fixed arrayRemove() helper function

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -1286,8 +1286,10 @@ persistence.get = function(arg1, arg2) {
         var el = ar[i];
         if(el.equals && el.equals(item)) {
           ar.splice(i, 1);
+          return;
         } else if(el === item) {
           ar.splice(i, 1);
+          return;
         }
       }
     }

--- a/test/browser/test.persistence.js
+++ b/test/browser/test.persistence.js
@@ -228,6 +228,24 @@ $(document).ready(function(){
         });
     });
 
+  asyncTest("Many-to-many with local changes", function() {
+      var t = new Task({name: "Some task"});
+      persistence.add(t);
+      t.tags.list(function(tags) {
+          equals(tags.length, 0, "Initially, no tags");
+          var tag1 = new Tag({name: "important"});
+          var tag2 = new Tag({name: "today"});
+          t.tags.add(tag1);
+          t.tags.add(tag2);
+          t.tags.remove(tag1);
+          t.tags.list(function(tags) {
+              equals(tags.length, 1, "2 tags added, 1 removed");
+              equals(tags[0].id, tag2.id, "Correct tag left");
+              start();
+            });
+        });
+    });
+
   module("Query collections", {
       setup: function() {
         stop();


### PR DESCRIPTION
The function was broken in a way that when it actually removed an item from
the array, it would run over the end of the array, throwing an exception
trying to work with a null element. Fixed by returning directly after
deleting an element. This is OK since the method is only used for arrays
without duplicate elements.

Also added a test case that uses arrayRemove() (indirectly).
