### PR TITLE
Fixed removing local (_new) objects

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -277,10 +277,14 @@ persistence.get = function(arg1, arg2) {
      * @param obj object to be removed
      */
     persistence.remove = function(obj) {
-      if (!this.objectsToRemove[obj.id]) {
-        this.objectsToRemove[obj.id] = obj;
+      if (obj._new) {
+        delete this.trackedObjects[obj.id];
+      } else {
+        if (!this.objectsToRemove[obj.id]) {
+          this.objectsToRemove[obj.id] = obj;
+        }
+        this.objectsRemoved.push({id: obj.id, entity: obj._type});
       }
-      this.objectsRemoved.push({id: obj.id, entity: obj._type});
       this.objectRemoved(obj);
       return this;
     };

--- a/test/browser/test.persistence.js
+++ b/test/browser/test.persistence.js
@@ -182,6 +182,39 @@ $(document).ready(function(){
         });
     });
 
+  asyncTest("Removing objects", function() {
+      var originalTasks = [];
+      var counter = 0;
+      for(var i = 0; i < 25; i++) {
+        var t = new Task({name: "Task " + i});
+        t.counter = counter;
+        originalTasks.push(t);
+        persistence.add(t);
+        counter++;
+      }
+      for(var i = 0; i < 5; i++) {
+        persistence.remove(originalTasks[i]);
+      }
+      Task.all().order('counter', true).list(function(tasks) {
+          equals(tasks.length, 20, 'Correct count after removing local objects');
+          for(var i = 5; i < 25; i++) {
+            equals(tasks[i - 5].id, originalTasks[i].id, 'Correct objects after removing local objects');
+          }
+
+          for(var i = 5; i < 10; i++) {
+            persistence.remove(originalTasks[i]);
+          }
+          Task.all().order('counter', true).list(function(tasks) {
+              equals(tasks.length, 15, 'Correct count after removing persisted objects');
+              for(var i = 10; i < 25; i++) {
+                equals(tasks[i - 10].id, originalTasks[i].id, 'Correct objects after removing persisted objects');
+              }
+
+              start();
+            });
+        });
+    });
+
   asyncTest("One-to-many", function() {
       var p = new Project({name: "Some project"});
       persistence.add(p);


### PR DESCRIPTION
If an object was created, added and removed without flushing in between, it was still persisted. Fixed by directly removing `_new` objects from the `trackedObjects` array.

**PLEASE NOTE:** This change touches sync functionality, by moving the `this.objectsRemoved.push()` call into the `else` clause. As far as I can tell, this seems to be the right thing to do. However, I wasn't able to run the sync tests on my Windows setup -- so please only merge this after running the sync tests.
