### PR TITLE
Account for skip and limit in DbQueryCollection::count()

### DIFF
--- a/lib/persistence.store.sql.js
+++ b/lib/persistence.store.sql.js
@@ -833,7 +833,19 @@ function config(persistence, dialect) {
     var args = [];
     var whereSql = "WHERE " + [ this._filter.sql(meta, "root", args) ].concat(additionalWhereSqls).join(' AND ');
 
-    var sql = "SELECT COUNT(*) AS cnt FROM `" + entityName + "` AS `root` " + joinSql + " " + whereSql;
+    var skipLimitSql = '';
+    if(this._limit >= 0) {
+      skipLimitSql += " LIMIT " + this._limit;
+    }
+    if(this._skip > 0) {
+      skipLimitSql += " OFFSET " + this._skip;
+    }
+
+    if (skipLimitSql === '') {
+      var sql = "SELECT COUNT(*) AS cnt FROM `" + entityName + "` AS `root` " + joinSql + " " + whereSql;
+    } else {
+      var sql = "SELECT COUNT(*) AS cnt FROM (SELECT id FROM `" + entityName + "` AS `root` " + joinSql + " " + whereSql + skipLimitSql + ")";
+    }
 
     session.flush(tx, function () {
         tx.executeSql(sql, args, function(results) {

--- a/test/browser/test.persistence.js
+++ b/test/browser/test.persistence.js
@@ -532,12 +532,15 @@ $(document).ready(function(){
       tasks.push(t);
       coll.add(t);
     }
-    coll.order("counter", true).limit(5).list(function(results) {
-        equals(results.length, 5, "Result length check");
-        for(var i = 0; i < 5; i++) {
-          equals(results[i].id, tasks[i].id, "limit check");
-        }
-        start();
+    coll.order("counter", true).limit(5).count(function(count) {
+        equals(count, 5, "Count check");
+        coll.order("counter", true).limit(5).list(function(results) {
+            equals(results.length, 5, "Result length check");
+            for(var i = 0; i < 5; i++) {
+              equals(results[i].id, tasks[i].id, "limit check");
+            }
+            start();
+          });
       });
   }
 
@@ -548,12 +551,15 @@ $(document).ready(function(){
       tasks.push(t);
       coll.add(t);
     }
-    coll.order("counter", true).skip(5).limit(5).list(function(results) {
-        equals(results.length, 5, "Result length check");
-        for(var i = 5; i < 10; i++) {
-          equals(results[i-5].id, tasks[i].id, "skip check");
-        }
-        start();
+    coll.order("counter", true).skip(5).limit(5).count(function(count) {
+        equals(count, 5, "Count check");
+        coll.order("counter", true).skip(5).limit(5).list(function(results) {
+            equals(results.length, 5, "Result length check");
+            for(var i = 5; i < 10; i++) {
+              equals(results[i-5].id, tasks[i].id, "skip check");
+            }
+            start();
+          });
       });
   }
 


### PR DESCRIPTION
The SQL generated by DbQueryCollections::count() did not account for the skip
and limit values of the QueryCollection, and always returned the total count.
Fixed by counting the result of a sub-query if necessary.
