### PR TITLE
Fix #97 Migrating downwards goes too far

### DIFF
--- a/lib/persistence.migrations.js
+++ b/lib/persistence.migrations.js
@@ -161,9 +161,9 @@ if(!window.persistence) { // persistence.js not loaded!
       this.actions = [];
     };
     
-    Migration.prototype.executeActions = function(callback) {
+    Migration.prototype.executeActions = function(callback, customVersion) {
       var actionsToRun = this.actions;
-      var version = this.version;
+      var version = (customVersion!==undefined) ? customVersion : this.version;
       
       persistence.transaction(function(tx){
         function nextAction() {
@@ -186,7 +186,7 @@ if(!window.persistence) { // persistence.js not loaded!
     
     Migration.prototype.down = function(callback) {
       if (this.body.down) this.body.down.apply(this);
-      this.executeActions(callback);
+      this.executeActions(callback, this.version-1);
     }
     
     Migration.prototype.createTable = function(tableName, callback) {


### PR DESCRIPTION
When migrating downwards, don't migrate down the version we're trying to get to.

This should fix #97 .
