### PR TITLE
Fix #99. Break up big queries into little ones

### DIFF
--- a/lib/persistence.sync.js
+++ b/lib/persistence.sync.js
@@ -134,7 +134,7 @@ persistence.sync.postJSON = function(uri, data, callback) {
       // Step 1: Look at local versions of remotely updated entities
       var existingItems = [], groupedIds = [];
       for (var i=0,l=Math.floor((ids.length/100)+1);i<l;i++) {
-        groupedIds.push(ids.slice(i*100, 100));
+        groupedIds.push(ids.slice(i*100, i*100+100));
       }
       persistence.asyncForEach(groupedIds, function(idGroup, next) {
         Entity.all(session).filter('id', 'in', idGroup).list(function(groupOfExistingItems) {
@@ -176,7 +176,7 @@ persistence.sync.postJSON = function(uri, data, callback) {
           // Step 2: Remove all remotely removed objects
           var groupedObjectsToRemove = [];
           for (var i=0,l=Math.floor((objectsToRemove.length/100)+1);i<l;i++) {
-            groupedObjectsToRemove.push(objectsToRemove.slice(i*100,100));
+            groupedObjectsToRemove.push(objectsToRemove.slice(i*100, i*100+100));
           }
           persistence.asyncForEach(groupedObjectsToRemove, function(group, next) {
             Entity.all(session).filter('id', 'in', group).destroyAll(next);


### PR DESCRIPTION
Also does the filtering out in code in one of them.

This fixes #99 where if there are too many ids, these queries can fail to work.
