### PR TITLE
Fix #79. Only need to work with objectsRemoved once

### DIFF
--- a/lib/persistence.sync.js
+++ b/lib/persistence.sync.js
@@ -322,6 +322,7 @@ persistence.sync.postJSON = function(uri, data, callback) {
               session.add(new persistence.sync.RemovedObject({entity: rec.entity, objectId: rec.id}));
             }
           });
+        session.objectsRemoved=[];
         callback();
       });
 


### PR DESCRIPTION
It appeared no where else was objectsRemoved was being cleared normally.

Not sure if this belongs here or in flush somewhere instead.
