### PR TITLE
Improper clearing of objects in race conditions

### DIFF
--- a/lib/persistence.store.sql.js
+++ b/lib/persistence.store.sql.js
@@ -592,6 +592,10 @@ function config(persistence, dialect) {
         });
       return;
     }
+    
+    //clean persistencejs
+    persistence.clean();
+    
     var entityName = this._entityName;
     var meta = persistence.getMeta(entityName);
     var tm = persistence.typeMapper;


### PR DESCRIPTION
## Problem

When doing multiple queries back-to-back, persistence will return the wrong object when using the .list(tx, callback) function. I fist discussed in the google group earlier today, https://groups.google.com/forum/?fromgroups=#!topic/persistencejs/wChS50a1JRY.
## Fix

Call persistence.clean() before making the query to ensure proper clearing of objects and returning to the user what is expected.
## Test

The test for this fix is housed inside of https://gist.github.com/3656872. With index.html containing existing code that demonstrates the problem, and index_fixed.html pointing to my cloned repo which demonstrates the fix. The console outputs the object._type.

Before Fix:
The console output : https://gist.github.com/3656872#file_console_output.txt. Here, you can clearly see that the wrong objects are being returned.

After Fix: 
The console output: https://gist.github.com/3656872#file_console_output_fixed.txt. After the fix, you can see that the correct objects are being returned.
## Git Commit Message

This fix is to ensure that PersistenceJS always returns only those
objects that it has just queried, no matter how fast the queries are
happening. By calling persistence.clean(); after we ensure we have a
transaction, the following objects are cleared:
this.trackedObjects
this.objectsToRemove
this.objectsRemoved
this.globalPropertyListeners
this.queryCollectionCache
