### PR TITLE
Fix __defineSetter__ & __defineGetter__ issued by IE9

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -28,11 +28,23 @@ if (typeof exports !== 'undefined') {
 		return initPersistence({})
 	}
 	var singleton;
-	exports.__defineGetter__("persistence", function () {
-    	if (!singleton)
-	  		singleton = exports.createPersistence();
-	  	return singleton;
-	});
+	if (typeof (exports.__defineGetter__) === 'function') {
+	    exports.__defineGetter__("persistence", function () {
+	        if (!singleton)
+	            singleton = exports.createPersistence();
+	        return singleton;
+	    });
+	} else {
+	    Object.defineProperty(exports, "persistence", {
+	        get: function () {
+	            if (!singleton)
+	                singleton = exports.createPersistence();
+	            return singleton;
+	        },
+	        enumerable: true, configurable: true
+	    });
+	}
+
 }
 else {
 	window = window || {};
@@ -55,12 +67,22 @@ persistence.isImmutable = function(fieldName) {
  * Default implementation for entity-property
  */
 persistence.defineProp = function(scope, field, setterCallback, getterCallback) {
-  scope.__defineSetter__(field, function (value) {
-      setterCallback(value);
-    });
-  scope.__defineGetter__(field, function () {
-      return getterCallback();
-    });
+    if (typeof (scope.__defineSetter__) === 'function' && typeof (scope.__defineGetter__) === 'function') {
+        scope.__defineSetter__(field, function (value) {
+            setterCallback(value);
+        });
+        scope.__defineGetter__(field, function () {
+            return getterCallback();
+        });
+    } else {
+        Object.defineProperty(scope, field, {
+            get: getterCallback,
+            set: function (value) {
+                setterCallback(value);
+            },
+            enumerable: true, configurable: true
+        });
+    }
 };
 
 /**


### PR DESCRIPTION
I saw the discussion on  https://github.com/zefhemel/persistencejs/issues/80 and try to implement it, it works on IE, Firefox & Chrome by only tweak **defineSetter** & **defineGetter**  stuff only.
