### PR TITLE
Sync of removed objects Doesnt work for nodejs server

### DIFF
--- a/lib/persistence.sync.server.js
+++ b/lib/persistence.sync.server.js
@@ -101,7 +101,7 @@ exports.pushUpdates = function(session, tx, Entity, since, callback) {
       if(since>0){
         session.sync.RemovedObject.all(session).filter("entity", "=", meta.name).filter("date", ">", since).list(tx, function(items) {
             for(var i = 0; i < items.length; i++) {
-              results.push({id: items[i].id, _removed: true});
+              results.push({id: items[i].objectId, _removed: true});
             }
             callback({now: getEpoch(new Date()), updates: results});
           });


### PR DESCRIPTION
Sync of removed objects doesnt work for nodejs server sync, as we are sending back id, which is the auto generated id of sync table rather than objectId.
