### PR TITLE
Add error callback to list() on DbQueryCollection in store.sql as sql might fail

### DIFF
--- a/lib/persistence.store.sql.js
+++ b/lib/persistence.store.sql.js
@@ -579,19 +579,21 @@ function config(persistence, dialect) {
    * @param callback function to be called taking an array with
    *   result objects as argument
    */
-  persistence.DbQueryCollection.prototype.list = function (tx, callback) {
+  persistence.DbQueryCollection.prototype.list = function (tx, callback, errorCallback) {
     var args = argspec.getArgs(arguments, [
         { name: 'tx', optional: true, check: persistence.isTransaction, defaultValue: null },
-        { name: 'callback', optional: false, check: argspec.isCallback() }
+        { name: 'callback', optional: false, check: argspec.isCallback() },
+        { name: 'errorCallback', optional: true, check: argspec.isCallback(), defaultValue: null }
       ]);
     tx = args.tx;
     callback = args.callback;
+    errorCallback = args.errorCallback;
 
     var that = this;
     var session = this._session;
     if(!tx) { // no transaction supplied
       session.transaction(function(tx) {
-          that.list(tx, callback);
+          that.list(tx, callback, errorCallback);
         });
       return;
     }
@@ -708,6 +710,13 @@ function config(persistence, dialect) {
             }
             callback(results);
             that.triggerEvent('list', that, results);
+          }, function (tx, error) {
+            if (persistence.debug) {
+              console.log(tx, error);
+            }
+            if (typeof errorCallback == 'function') {
+              errorCallback(tx, error);
+            }
           });
       });
   };


### PR DESCRIPTION
All the sql stores has error callbacks in their executeSql methods, but the `list()` method in store.sql doesn't use them. So when a query fails, you'll never know.

I ran into this issue while using the migration plugin, i accidentally created a table with the plural version of the entity's name, and didn't get any callbacks while using the `list()` function after doing `Entity.all()`.

I added support for error callbacks in `.list()` on `DbQueryCollection`, to fix this issue.
