### PR TITLE
Support for ordering with nested objects in SQL

### DIFF
--- a/lib/persistence.store.sql.js
+++ b/lib/persistence.store.sql.js
@@ -651,6 +651,7 @@ function config(persistence, dialect) {
 
     joinSql += this._additionalJoinSqls.join(' ');
 
+    var prefetchedFieldsAliases = {};
     for ( var i = 0; i < this._prefetchFields.length; i++) {
       var prefetchFieldParts = this._prefetchFields[i].split('.');
       var prefetchField = prefetchFieldParts[0];
@@ -672,6 +673,7 @@ function config(persistence, dialect) {
           prefetchField + "_"));
       joinSql += "LEFT JOIN `" + thisMeta.name + "` AS `" + tableAlias
       + "` ON `" + tableAlias + "`.`id` = `" + PrefetchFrom + '`.`' + prefetchField + "` ";
+      prefetchedFieldsAliases[prefetchField] = tableAlias;
 
     }
 
@@ -689,9 +691,14 @@ function config(persistence, dialect) {
       sql += " ORDER BY "
       + this._orderColumns.map(
         function (c) {
-          return (c[2] ? "`" : "LOWER(`") + mainPrefix + c[0] + (c[2] ? "` " : "`) ")
-          + (c[1] ? "ASC" : "DESC");
-        }).join(", ");
+            var field = null, dotIndex = c[0].lastIndexOf(".");
+            if (dotIndex > -1
+              && typeof prefetchedFieldsAliases[c[0].substring(0, dotIndex)] === "string") {
+              field = prefetchedFieldsAliases[c[0].substring(0, dotIndex)] + "`.`" + c[0].substring(dotIndex + 1);
+            } else field = mainPrefix + c[0];
+            return (c[2] ? "`" : "LOWER(`") + field + (c[2] ? "` " : "`) ")
+              + (c[1] ? "ASC" : "DESC");
+          }).join(", ");
     }
     if(this._limit >= 0) {
       sql += " LIMIT " + this._limit;


### PR DESCRIPTION
Allows to use .order('parent.field') after .prefetch('parent'). Example from my project code:
ZCard.all().prefetch('brand').order('brand.name').forEach(function (card) {});
