### PR TITLE
- Use UTF-8 as encoding to send data to server

### DIFF
--- a/lib/persistence.sync.js
+++ b/lib/persistence.sync.js
@@ -48,7 +48,7 @@ persistence.sync.getJSON = function(uri, callback, errorCallback) {
 persistence.sync.postJSON = function(uri, data, callback) {
     var xmlHttp = new XMLHttpRequest();
     xmlHttp.open("POST", uri, true);
-    xmlHttp.setRequestHeader('Content-Type', 'application/json');
+    xmlHttp.setRequestHeader('Content-Type', 'application/json;charset=utf-8');
     xmlHttp.send(data);
     xmlHttp.onreadystatechange = function() {
       if(xmlHttp.readyState==4 && xmlHttp.status==200) {
@@ -180,9 +180,9 @@ persistence.sync.postJSON = function(uri, data, callback) {
           }
 
           /* ensure IDs var chars */
-          var idVals = new Array();
-          for(var id=0;id<group.length;id++){
-            idVals.push( persistence.typeMapper.entityIdToDbId(group[id]));
+          var idVals = [];
+          for(var id=0;id<groupedIds.length;id++){
+            idVals.push( persistence.typeMapper.entityIdToDbId(groupedIds[id]));
           }
 
           persistence.asyncForEach(groupedObjectsToRemove, function(group, next) {


### PR DESCRIPTION
Small fixes on sync :
- Use UTF-8 to send data to server, else, special characters like ç, é, è are not encoded correctly
- Use groupedIds instead of undefined variable group in order to avoid error
