### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "persistence",
   "main": "./lib/persistence.js",
-  "version": "0.3.0",
   "_release": "0.3.0",
   "_target": "~0.3.0",
   "_source": "git://github.com/zefhemel/persistencejs.git",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property