### PR TITLE
Resolve issue with Issue with calling persistence.migrate with no par…

### DIFF
--- a/lib/persistence.migrations.js
+++ b/lib/persistence.migrations.js
@@ -138,8 +138,10 @@ if(!window.persistence) { // persistence.js not loaded!
       },
       
       migrate: function(version, callback) {
-        if ( arguments.length === 1 ) {
+        if ( arguments.length === 1) {
           callback = version;
+        }
+        if ( arguments.length <= 1) {
           version = this.migrations.length-1;
         }
         


### PR DESCRIPTION
Per documentation: persistence.migrate() to run migrations up to the most recent

I encountered an issue where calling persistence.migrate with no parameters didn't do anything. Checking the code of persistence.migrations.js, I found the problem where version is undefined and thus no migration is done and only the callback is called:
if (curVersion < version)
Migrator.migrateUpTo(version, callback);
else if (curVersion > version)
Migrator.migrateDownTo(version, callback);
else
callback();

Solution is to update code from:
migrate: function(version, callback) {
if ( arguments.length === 1) {
callback = version;
version = this.migrations.length-1;
}

to:
migrate: function(version, callback) {
if ( arguments.length === 1) {
callback = version;
}
if (arguments.lemgth <= 1) {
version = this.migrations.length-1;
}