### PR TITLE
Supporting iOS location parameter to control iTunes/iCloud backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,18 @@ Use following if you want to use `persistencejs` in a [Cordova](https://cordova.
       'yourdbname',
       '0.0.1',                // DB version
       'My database',          // DB display name
-      5 * 1024 * 1024,        // DB size
-      0                       // SQLitePlugin Background processing disabled
+      5 * 1024 * 1024,        // DB size (WebSQL fallback only)
+      0,                      // SQLitePlugin Background processing disabled
+      2                       // DB location (iOS only), 0 (default): Documents, 1: Library, 2: Library/LocalDatabase
+                              //   0: iTunes + iCloud, 1: NO iTunes + iCloud, 2: NO iTunes + NO iCloud
+                              //   More information at https://github.com/litehelpers/Cordova-sqlite-storage#opening-a-database
     );
 
 For more information on the SQLitePlugin background processing please refer to the [SQLitePlugin](https://github.com/brodysoft/Cordova-SQLitePlugin) readme.
 
 The Cordova support in `persistencejs` will try to work with the [SQLitePlugin](https://github.com/brodysoft/Cordova-SQLitePlugin) if it is loaded; if not it will automatically fall back to [WebSQL](http://docs.phonegap.com/en/edge/cordova_storage_storage.md.html#Storage).
+
+Please note that to use Cordova store, you must use the master branch, because it is not included up to release v0.3.0.
 
 The in-memory store
 ---------------------------------------

--- a/lib/persistence.store.cordovasql.js
+++ b/lib/persistence.store.cordovasql.js
@@ -25,8 +25,9 @@ persistence.store.cordovasql = {};
  * @param description
  * @param size
  * @param backgroundProcessing
+ * @param iOSLocation
  */
-persistence.store.cordovasql.config = function (persistence, dbname, dbversion, description, size, backgroundProcessing) {
+persistence.store.cordovasql.config = function (persistence, dbname, dbversion, description, size, backgroundProcessing, iOSLocation) {
   var conn = null;
 
   /**
@@ -67,11 +68,12 @@ persistence.store.cordovasql.config = function (persistence, dbname, dbversion, 
    *
    * @param dbname
    * @param backgroundProcessing
+   * @param iOSLocation
    * @returns {{}}
    */
-  persistence.db.sqliteplugin.connect = function (dbname, backgroundProcessing) {
+  persistence.db.sqliteplugin.connect = function (dbname, backgroundProcessing, iOSLocation) {
     var that = {};
-    var conn = window.sqlitePlugin.openDatabase({name: dbname, bgType: backgroundProcessing});
+    var conn = window.sqlitePlugin.openDatabase({name: dbname, bgType: backgroundProcessing, location: (iOSLocation || 0)});
 
     that.transaction = function (fn) {
       return conn.transaction(function (sqlt) {
@@ -165,11 +167,12 @@ persistence.store.cordovasql.config = function (persistence, dbname, dbversion, 
    * @param description
    * @param size
    * @param backgroundProcessing
+   * @param iOSLocation
    * @returns {*}
    */
-  persistence.db.connect = function (dbname, dbversion, description, size, backgroundProcessing) {
+  persistence.db.connect = function (dbname, dbversion, description, size, backgroundProcessing, iOSLocation) {
     if (persistence.db.implementation == "sqliteplugin") {
-      return persistence.db.sqliteplugin.connect(dbname, backgroundProcessing);
+      return persistence.db.sqliteplugin.connect(dbname, backgroundProcessing, iOSLocation);
     } else if (persistence.db.implementation == "websql") {
       return persistence.db.websql.connect(dbname, dbversion, description, size);
     }
@@ -225,7 +228,7 @@ persistence.store.cordovasql.config = function (persistence, dbname, dbversion, 
   persistence.store.sql.config(persistence, persistence.store.cordovasql.sqliteDialect);
 
   // Make the connection
-  conn = persistence.db.connect(dbname, dbversion, description, size, backgroundProcessing);
+  conn = persistence.db.connect(dbname, dbversion, description, size, backgroundProcessing, iOSLocation);
   if (!conn) {
     throw new Error("No supported database found in this browser.");
   }


### PR DESCRIPTION
Since [18th Feb, 2015](https://github.com/litehelpers/Cordova-sqlite-storage/releases/tag/r2015.02), Cordova Sqlite plugin supports [changing database location](https://github.com/litehelpers/Cordova-sqlite-storage#opening-a-database) (iOS only) to control iTunes/iCloud backup. This pull request propagate this new configuration.