### PR TITLE
Fixing a bug where persistence.transaction would call websql instead of sqliteplugin

### DIFF
--- a/lib/persistence.store.cordovasql.js
+++ b/lib/persistence.store.cordovasql.js
@@ -77,7 +77,7 @@ persistence.store.cordovasql.config = function (persistence, dbname, dbversion, 
 
     that.transaction = function (fn) {
       return conn.transaction(function (sqlt) {
-        return fn(persistence.db.websql.transaction(sqlt));
+        return fn(persistence.db.sqliteplugin.transaction(sqlt));
       });
     };
     return that;


### PR DESCRIPTION
This is very weird. Such bug existed for so long with no one discovering it, although it would cause a disaster. When calling persistence.transaction when the native sqliteplugin is active, it would delegate to websql driver rather than sqliteplugin. With this fix, I have been testing persistence.transaction to issue raw queries for long on a device with sqliteplugin loaded. Please tell me if i am missing something. 
