### PR TITLE
Prevent error in lack of migrations

### DIFF
--- a/lib/persistence.migrations.js
+++ b/lib/persistence.migrations.js
@@ -85,8 +85,11 @@ if(!window.persistence) { // persistence.js not loaded!
         function migrateOne() {
           var migration = migrationsToRun.pop();
           
-          if (!migration) callback();
-          
+          if (!migration) {
+            callback();
+            return;
+          }
+
           migration.up(function(){
             if (migrationsToRun.length > 0) {
               migrateOne();


### PR DESCRIPTION
If there is no migrations, the method migrateOne throw one error. This happen because the code don't stop after "callback()", so added "return" also;
