### PR TITLE
Don't index a field if it is null or blank

### DIFF
--- a/lib/persistence.search.js
+++ b/lib/persistence.search.js
@@ -260,6 +260,9 @@ persistence.search.config = function(persistence, dialect) {
             for ( var p in obj._dirtyProperties) {
               if (obj._dirtyProperties.hasOwnProperty(p) && p in meta.textIndex) {
                 queries.push(['DELETE FROM `' + indexTbl + '` WHERE `entityId` = ? AND `prop` = ?', [id, p]]);
+                if (!(obj._data[p] && obj._data[p].length)) {
+                  continue;
+                }
                 var occurrences = searchTokenizer(obj._data[p]);
                 for(var word in occurrences) {
                   if(occurrences.hasOwnProperty(word)) {


### PR DESCRIPTION
Currently if the value for a field is null, attempting to index the field throws an error:

    Uncaught TypeError: Cannot read property 'toLowerCase' of null
        at searchTokenizer

This fix ignores a field if it is null or empty.